### PR TITLE
Bugfix for RHEL8 with Python3

### DIFF
--- a/libexec/oracle-systemd-service
+++ b/libexec/oracle-systemd-service
@@ -168,7 +168,7 @@ def cgroups_checks():
                     # add all those pids to the cgroup by adding them one by one to the cgroups-proc-file
                     for non_cgroup_proc in cgroup_diff_list:
                         with open(cgroup_proc_list_file, 'a') as cgroup_proc_fh:
-                            cgroup_proc_fh.write(non_cgroup_proc)
+                            cgroup_proc_fh.write(non_cgroup_proc.decode('utf-8'))
                 except Exception as e:
                     log.error('Failed to write to file {} {}'.format(cgroup_proc_list_file, str(e)))
             else:
@@ -192,7 +192,7 @@ def cgroups_checks():
                     # add all those pids to the cgroup by adding them one by one to the cgroups-proc-file
                     for non_cgroup_proc in cgroup_diff_list:
                         with open(cgroup_proc_list_file, 'a') as cgroup_proc_fh:
-                            cgroup_proc_fh.write(non_cgroup_proc)
+                            cgroup_proc_fh.write(non_cgroup_proc.decode('utf-8'))
                 except Exception as e:
                     log.error('Failed to write to file {} {}'.format(cgroup_proc_list_file, str(e)))
             else:


### PR DESCRIPTION
This change is needed for RHEL8 with Python3.

It fixes following bug in syslog:

`Failed to write to file /sys/fs/cgroup/systemd/system.slice/oracle.service/cgroup.procs write() argument must be str, not bytes`

I tested it with OL7 with Python2.7.5, too.