### PR TITLE
Set full path for kill to avoid systemd error:

### DIFF
--- a/systemd/oracle.service
+++ b/systemd/oracle.service
@@ -15,7 +15,7 @@ TimeoutStopSec=5min
 LimitNOFILE=16384
 LimitMEMLOCK=128G
 ExecStart=/usr/libexec/oracle-systemd-service
-ExecReload=kill -HUP $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGUSR2
 KillMode=process
 


### PR DESCRIPTION
"Executable path is not absolute, ignoring: xxx"